### PR TITLE
Open API 연동 / Client 공통 API 메서드 분기

### DIFF
--- a/src/main/java/com/sprint/mission/findex/client/FindexOpenApiClient.java
+++ b/src/main/java/com/sprint/mission/findex/client/FindexOpenApiClient.java
@@ -5,10 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.util.UriUtils;
 import reactor.core.publisher.Mono;
-
-import java.nio.charset.StandardCharsets;
 
 @Component
 @RequiredArgsConstructor
@@ -19,26 +16,46 @@ public class FindexOpenApiClient {
     private String serviceKey;
 
     /*
-        지정된 날짜와 지수명에 해당하는 주식 정보를 외부 API로부터 비동기 호출
+        [지수 정보]
+        지정된 날짜에 해당하는 주식 정보를 외부 API로부터 비동기 호출
         ------------------------------------------------------
         @param baseDate 조회할 기준 날짜
-        @param indexName 조회할 지수 명칭
         @return Mono<StockIndexResponse> 비동기 응답 객체
     */
-    public Mono<StockMarketIndexResponseDto> fetchStockIndex(String baseDate, String indexName) {
-        String encodedIndexName = UriUtils.encode(indexName, StandardCharsets.UTF_8);            // UTF-8 수동 인코딩
-
+    public Mono<StockMarketIndexResponseDto> fetchStockIndexInfo(String baseDate) {
         return publicDataWebClient.get()                                                         // GET 요청 설정
                 .uri(uriBuilder ->  uriBuilder
-                            .path("/getStockMarketIndex")                                        // 지수 시세 정보 세부 경로
-                            .queryParam("serviceKey", serviceKey)                          // 필수 인증키 파라미터를 추가합니다.
-                            .queryParam("resultType", "json")                      // 응답 결과 타입을 JSON으로 지정합니다.
-                            .queryParam("basDt", baseDate)                                 // 조회 일자를 필터로 설정합니다.
-                            .queryParam("idxNm", encodedIndexName)                         // 조회 지수명을 필터로 설정합니다.
-                            .build(true))                                            // true = 해당 uri가 인코딩 된 값임을 의미
-                .retrieve()                                                                      // 응답 생성
-                .bodyToMono(StockMarketIndexResponseDto.class)                                   // 응답 바디 -> DTO 클래스 변환
-                .doOnError(e ->                                                        // 에러 메시지
-                            System.out.println("Open API 호출 에러 : " + e.getMessage()));
+                        .path("/getStockMarketIndex")                                           // 지수 시세 정보 세부 경로 설정
+                        .queryParam("serviceKey", serviceKey)                             // 필수 파라미터인 공공데이터포털 인증키 추가
+                        .queryParam("resultType", "json")                         // 응답 결과 타입 = JSON
+                        .queryParam("basDt", baseDate)                                    // 조건 필터: 조회 일자
+                        .build(true))                                               // true = 해당 uri가 인코딩 된 값임을 의미
+                .retrieve()                                                                     // 응답 생성
+                .bodyToMono(StockMarketIndexResponseDto.class)                                  // 응답 바디 -> DTO 클래스 변환
+                .doOnError(e ->                                                       // 에러 메시지
+                        System.out.println("Open API 호출 에러 : " + e.getMessage()));
+    }
+
+    /*
+        [지수 데이터]
+        지정된 날짜와 특정 지수 정보에 해당하는 주식 정보를 외부 API로부터 비동기 호출
+        ------------------------------------------------------
+        @param baseDate 조회할 기준 날짜
+        @param IndexInfoId 조회할 지수 정보 ID
+        @return Mono<StockIndexResponse> 비동기 응답 객체
+    */
+    public Mono<StockMarketIndexResponseDto> fetchStockIndexData(String baseDate, String indexName) {
+        return publicDataWebClient.get()                                                     // GET 요청 설정
+                .uri(uriBuilder ->  uriBuilder
+                        .path("/getStockMarketIndex")                                        // 지수 시세 정보 세부 경로
+                        .queryParam("serviceKey", serviceKey)                          // 필수 파라미터인 공공데이터포털 인증키 추가
+                        .queryParam("resultType", "json")                      // 응답 결과 타입 = JSON
+                        .queryParam("basDt", baseDate)                                 // 조건 필터: 조회 일자
+                        .queryParam("indexName", indexName)                            // 조건 필터: 지수명
+                        .build(true))                                            // true = 해당 uri가 인코딩 된 값임을 의미
+                .retrieve()                                                                  // 응답 생성
+                .bodyToMono(StockMarketIndexResponseDto.class)                               // 응답 바디 -> DTO 클래스 변환
+                .doOnError(e ->                                                    // 에러 메시지
+                        System.out.println("Open API 호출 에러 : " + e.getMessage()));
     }
 }

--- a/src/test/java/com/sprint/mission/findex/client/FindexOpenApiClientTest.java
+++ b/src/test/java/com/sprint/mission/findex/client/FindexOpenApiClientTest.java
@@ -30,7 +30,7 @@ class FindexOpenApiClientTest {
         String testIndex = "코스피";
 
         // 2. 외부 API 호출 및 응답 데이터 수신
-        StockMarketIndexResponseDto result = findexOpenApiClient.fetchStockIndex(testDate, testIndex).block();
+        StockMarketIndexResponseDto result = findexOpenApiClient.fetchStockIndexInfo(testDate).block();
 
         // 3. 응답 객체 및 바디의 Null 여부 검증
         assertNotNull(result);


### PR DESCRIPTION
## 관련 이슈
- #53 

## 작업 내용
- FindexOpenApiClient 내 함수 분기

## 변경 사항
- 함수 분기: 지수 정보 / 데이터의 외부 API 호출 시 사용 목적 및 필요한 파라미터에 따른 함수 분기

## 반영 브랜치
`feat/client` -> `develop`