### PR TITLE
연동 작업 목록 조회 / 연동 이력 조회 시 상태값(ENUM) 매핑 오류 수정

### DIFF
--- a/src/main/java/com/sprint/mission/findex/syncjob/entity/JobResult.java
+++ b/src/main/java/com/sprint/mission/findex/syncjob/entity/JobResult.java
@@ -3,5 +3,5 @@ package com.sprint.mission.findex.syncjob.entity;
 public enum JobResult {
   NEW,     // "접수됨/새로 생성됨" (Swagger JSON 예시 반영)
   SUCCESS, // "성공" ({결과} 설명 반영)
-  FAILURE  // "실패" ({결과} 설명 반영)
+  FAILED   // "실패" ({결과} 설명 반영)
 }

--- a/src/main/java/com/sprint/mission/findex/syncjob/service/SyncJobService.java
+++ b/src/main/java/com/sprint/mission/findex/syncjob/service/SyncJobService.java
@@ -258,7 +258,7 @@ public class SyncJobService {
                         .targetDate(targetDate)
                         .worker(worker)
                         .jobTime(LocalDateTime.now())
-                        .result(JobResult.FAILURE)
+                        .result(JobResult.FAILED)
                         .build();
 
                 syncJobRepository.save(failureSyncJob);


### PR DESCRIPTION
## 관련 이슈
- #37 
- #39 

## 작업 내용
- JobResult 필드명 수정: 오타 수정 (`FAILURE` -> `FAILED`)
- 프론트엔드 연동 테스트 및 버그 수정: 종료 날짜(jobTimeTo)를 확장했을 때, 당일 생성된 데이터들이 정상 노출됨을 확인

## 변경 사항
- JobResult.java: Enum 상수명 변경

## 테스트 결과
- 상태 필터: 화면에서 '실패' 선택 시 서버 에러 없이 정상적으로 실패 이력만 필터링 됨
- 날짜 조회: 오늘(3/17) 생성된 150여 건의 데이터가 리스트에 정상 출력됨을 확인
- 작업자 검색: 로컬 IP(0:0:0...1) 기준 부분 일치 검색 정상 작동 확인

## 반영 브랜치
`feat/syncJob/list` -> `develop`