### PR TITLE
자동연동 / 조회 로직 수정 (정렬, size, 전체지수 처리)

### DIFF
--- a/src/main/java/com/sprint/mission/findex/autosyncconfig/service/AutoSyncConfigServiceImpl.java
+++ b/src/main/java/com/sprint/mission/findex/autosyncconfig/service/AutoSyncConfigServiceImpl.java
@@ -12,6 +12,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -65,8 +66,18 @@ public class AutoSyncConfigServiceImpl implements AutoSyncConfigService {
     // 전체 데이터 개수 조회
     long totalElements = repository.count(specification);
 
-    // 다음 페이지 존재 여부 확인을 위해 size + 1 조회
-    Pageable pageable = PageRequest.of(0, size + 1);
+// 정렬 적용
+    Sort.Direction direction = "ASC".equalsIgnoreCase(sortDirection)
+        ? Sort.Direction.ASC
+        : Sort.Direction.DESC;
+
+// 다음 페이지 존재 여부 확인을 위해 size + 1 조회
+    Pageable pageable = PageRequest.of(
+        0,
+        size + 1,
+        Sort.by(direction, "id")
+    );
+
     List<AutoSyncConfig> entities = repository.findAll(specification, pageable).getContent();
 
     // 다음 페이지 존재 여부 판단
@@ -97,7 +108,7 @@ public class AutoSyncConfigServiceImpl implements AutoSyncConfigService {
         content,
         nextCursor,
         nextIdAfter,
-        content.size(),
+        size,
         totalElements,
         hasNext
     );

--- a/src/main/java/com/sprint/mission/findex/autosyncconfig/specification/AutoSyncConfigSpecification.java
+++ b/src/main/java/com/sprint/mission/findex/autosyncconfig/specification/AutoSyncConfigSpecification.java
@@ -18,16 +18,13 @@ public class AutoSyncConfigSpecification {
 
     return (root, query, criteriaBuilder) ->
 
-        // indexInfoId가 null이면 필터 조건을 추가하지 않음 → 전체 조회
-        indexInfoId == null
+        indexInfoId == null || indexInfoId <= 0
             ? null
-            // indexInfoId가 존재하면 indexInfo.id = indexInfoId 조건 생성
             : criteriaBuilder.equal(
                 root.get("indexInfo").get("id"),
                 indexInfoId
             );
   }
-
   /*
    * enabled 값으로 자동 연동 설정을 필터링
    * → enabled = true 인 설정만 조회


### PR DESCRIPTION
### **관련 이슈**

---

자동 연동 설정 조회 기능 이상 (필터/페이지네이션) #24 

### **작업 내용**

---

자동 연동 설정 목록 조회 API 점검

전체/활성화/비활성화 필터 동작 검증

커서 기반 페이지네이션 동작 확인

### **변경 사항**

---

size 값을 content.size() → 요청 size로 수정

indexInfoId 전체 조회 처리 (null, 0 이하 방어 로직 추가)

정렬 로직 추가 (id 기준 정렬 적용)

### **특이사항**

---

Postman 테스트 결과 백엔드 정상 동작 확인

프론트 요청에서 enabled 값이 잘못 전달되는 문제 확인

필터 변경 시 요청 중복 호출 발생 (프론트 상태 관리 이슈 추정)